### PR TITLE
Increase color contrast for entry-meta divs

### DIFF
--- a/style.css
+++ b/style.css
@@ -985,11 +985,11 @@ article > header > h2 {
 }
 
 .entry-meta {
-	color: rgb(179, 179, 179);
+	color: rgb(89, 89, 89);
 }
 
 .entry-meta a {
-	color: rgb(179, 179, 179);
+	color: rgb(89, 89, 89);
 }
 
 .cat-links {


### PR DESCRIPTION
Example:
"Posted on December 23, 2019 by nelson" in https://dc.sunrisemovement.org/updates/

For AAA conformance to WCAG guidelines, the text should be `rgb(89, 89, 89)` or darker.

For AA conformance to WCAG guidelines, the text should be `rgb(118, 118, 118)` or darker.

References:
- https://web.dev/color-contrast/
- https://www.w3.org/TR/WCAG21/#contrast-minimum